### PR TITLE
Update for Yosemite?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+Homebrew formula for pdftk
+forked from (docmunch/homebrew)[https://github.com/docmunch/homebrew-pdftk]

--- a/patch.diff
+++ b/patch.diff
@@ -46,6 +46,6 @@ index 8f7e52d..390c974 100644
  export GCJFLAGS= -Wall -fsource=1.3 -O2
  export GCJHFLAGS= -force
 -export LDLIBS= /sw/lib/gcc4.5/lib/libgcj.dylib /sw/lib/gcc4.5/lib/libstdc++.dylib /sw/lib/gcc4.5/lib/libgcc_s.1.dylib -liconv -lz
-+export LDLIBS= @PREFIX@/lib/gcc/@BUILD@/@GCC_VERSION@/libgcj.dylib @PREFIX@/lib/gcc/@BUILD@/@GCC_VERSION@/libstdc++.dylib @PREFIX@/lib/gcc/@BUILD@/@GCC_VERSION@/libgcc_s.1.dylib -liconv -lz
++export LDLIBS= /usr/local/Cellar/gcc48/4.8.4/lib/gcc/4.8/libgcj.dylib /usr/local/Cellar/gcc48/4.8.4/lib/gcc/4.8/libstdc++.dylib /usr/local/Cellar/gcc48/4.8.4/lib/gcc/4.8/libgcc_s.1.dylib -liconv -lz
  
  include Makefile.Base

--- a/pdftk.rb
+++ b/pdftk.rb
@@ -28,7 +28,7 @@ class Pdftk < Formula
         s.gsub! '@PREFIX@', Formula.factory('gcc48').prefix
         s.gsub! '@GCC_TOOL_VERSION@', "#{Formula.factory('gcc48').version}".sub(/(\d\.\d).*/,'-\1')
         s.gsub! '@GCC_VERSION@', Formula.factory('gcc48').version
-        s.gsub! '@BUILD@', "#{Formula.factory('gcc48').arch}-apple-darwin#{Formula.factory('gcc48').osmajor}"
+#       s.gsub! '@BUILD@', "#{Formula.factory('gcc48').arch}-apple-darwin#{Formula.factory('gcc48').osmajor}"
       end
 
       system 'make', '-f', 'Makefile.OSX-10.6'

--- a/pdftk.rb
+++ b/pdftk.rb
@@ -10,7 +10,8 @@ class Pdftk < Formula
   depends_on 'Homebrew/versions/gcc48' => [:build, 'enable-all-languages'] # or 'enable-java'
 
   def patches
-    'https://raw.githubusercontent.com/docmunch/homebrew-pdftk/fbe14dbb13d65a6847fc70ad521719ea9ad1353f/patch.diff'
+    'https://raw.githubusercontent.com/pborenstein/homebrew-pdftk/master/patch.diff'
+#    'https://raw.githubusercontent.com/docmunch/homebrew-pdftk/fbe14dbb13d65a6847fc70ad521719ea9ad1353f/patch.diff'
   end
 
   def install


### PR DESCRIPTION
Thanks for writing this formula. I created this fork to be able to be able to install pdftk on Yosemite. You definitely won't want to merge this directly. These are the changes I made:

* On my installation the `libgcj.dylib`,  `libstdc++.dylib`, and `libgcc_s.1.dylib` libraries weren't where the formula expected them. I hardcoded the paths because needed to get it working quickly.
* Commenting out the  `@BUILD@ ` replace.
* Hardcoded the path to the `patch.diff` to my repo.

